### PR TITLE
Add assertions

### DIFF
--- a/src/main/java/duke/task/TaskList.java
+++ b/src/main/java/duke/task/TaskList.java
@@ -49,6 +49,8 @@ public class TaskList {
      * @return Task specified by n.
      */
     public Task get(int n) {
+        assert (n > 0 && n < taskList.size()) : "WHAT TASK YOU REFERRING TO AH? HELLO YOU BETTER WAKE UP YOUR IDEA!";
+
         return taskList.get(n);
     }
 


### PR DESCRIPTION
Index of task to get is not checked.

Invalid index results in program crashing.

Checking the index before passing it to get() allows us to pass an
error message to the user instead of crashing the pogram.

Let's assert the index to make sure it is valid before passing it to
get().

Using assert allows us to document the assumption that index is valid.